### PR TITLE
ENG-292 env var into docker-compose to enable entando theme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN export KEYCLOAK_HTTP_PORT=8080 && \
       curl https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar -o driver/ojdbc.jar
 
 ENV KEYCLOAK_HTTP_PORT=8080
+ENV KEYCLOAK_DEFAULT_THEME="entando"
 EXPOSE 8080
 
 CMD ["-b", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.3'
 
 services:
   keycloak:
@@ -12,3 +12,4 @@ services:
       KEYCLOAK_PASSWORD: qwe123
       DB_VENDOR: h2
       PROXY_ADDRESS_FORWARDING: "true"
+      KEYCLOAK_DEFAULT_THEME: "entando"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,3 @@ services:
       KEYCLOAK_PASSWORD: qwe123
       DB_VENDOR: h2
       PROXY_ADDRESS_FORWARDING: "true"
-      KEYCLOAK_DEFAULT_THEME: "entando"


### PR DESCRIPTION
Added `KEYCLOAK_DEFAULT_THEME: "entando"` into `docker-compose.yml` in order to enable the entando theme as default theme